### PR TITLE
Add encoding to fs.readFileSync when loading polyfills

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ extendscriptr.options.forEach(function(opt) {
 	);
 });
 
-var prototypePolyfills = fs.readFileSync('./node_modules/extendscript.prototypes/lib/extendscript.prototypes.js');
+var prototypePolyfills = fs.readFileSync('./node_modules/extendscript.prototypes/lib/extendscript.prototypes.js', 'utf8');
 var browserifyPlugins = [ [ prependify, prototypePolyfills ] ];
 
 var adobeTarget = String(extendscriptr.target).toLowerCase();


### PR DESCRIPTION
This should resolve the issue I raised in #26.

It seems that without explicitly setting file encoding, `fs.readFileSync` was sending a buffer to prependify (instead of a string). Not sure what's different about my env, I'm on node v7.2.1 and npm v3.10.9.