### PR TITLE
fix(vulnerabilities): remove commitizen from project.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3449,15 +3449,6 @@
             "word-wrap": "1.2.3"
           }
         },
-        "detect-indent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
         "glob": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
@@ -3477,24 +3468,6 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
           "integrity": "sha1-NKMFW6vgTOQkZ7YH1wAHLH/2v0I=",
           "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.1"
-          }
         }
       }
     },
@@ -5679,6 +5652,15 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",
-    "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.1.0",
     "extendscript-bundlr": "^0.3.1",
     "semantic-release": "^4.3.5"


### PR DESCRIPTION
 Should be installed globally by the person who wants to use it. We should not force this process onto others

re #39